### PR TITLE
Add ktlint support and integrate it into CI

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Grant execute permission to gradlew
       run: chmod +x MakeAWish/gradlew
 
+    - name: Run ktlint check
+      run: cd MakeAWish && ./gradlew ktlintCheck
+
     - name: Build debug APK
       run: cd MakeAWish && ./gradlew assembleDebug
 

--- a/MakeAWish/.editorconfig
+++ b/MakeAWish/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.{kt,kts}]
+ktlint_code_style = ktlint_official
+indent_size = 4
+insert_final_newline = true
+max_line_length = 140
+# Disable function naming rule for Compose
+ktlint_standard_function-naming = disabled
+ktlint_standard_property-naming = disabled

--- a/MakeAWish/app/build.gradle
+++ b/MakeAWish/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.devtools.ksp'
+apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
     namespace "tt.co.jesses.makeawish"
@@ -79,4 +80,11 @@ dependencies {
     androidTestImplementation 'tools.fastlane:screengrab:2.1.1'
     testImplementation 'junit:junit:4.13.2'
 
+}
+
+ktlint {
+    android = true
+    reporters {
+        reporter "plain"
+    }
 }

--- a/MakeAWish/app/src/androidTest/java/tt/co/jesses/makeawish/ui/screens/MainScreenTest.kt
+++ b/MakeAWish/app/src/androidTest/java/tt/co/jesses/makeawish/ui/screens/MainScreenTest.kt
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class MainScreenTest {
-
     @get:Rule
     val composeTestRule = createComposeRule()
 

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/App.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/App.kt
@@ -13,7 +13,6 @@ import tt.co.jesses.makeawish.data.local.AppDatabase
  */
 
 class App : Application() {
-
     companion object {
         private val TAG = App::class.java.simpleName
         lateinit var database: AppDatabase
@@ -39,12 +38,12 @@ class App : Application() {
         val name = getString(R.string.channel_name)
         val descriptionText = getString(R.string.channel_description)
         val importance = android.app.NotificationManager.IMPORTANCE_DEFAULT
-        val channel = android.app.NotificationChannel("default", name, importance).apply {
-            description = descriptionText
-        }
+        val channel =
+            android.app.NotificationChannel("default", name, importance).apply {
+                description = descriptionText
+            }
         val notificationManager: android.app.NotificationManager =
             getSystemService(NOTIFICATION_SERVICE) as android.app.NotificationManager
         notificationManager.createNotificationChannel(channel)
     }
-
 }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/MainActivity.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/MainActivity.kt
@@ -34,22 +34,24 @@ import tt.co.jesses.makeawish.ui.theme.MakeAWishTheme
 import tt.co.jesses.makeawish.utils.Constants
 
 class MainActivity : ComponentActivity() {
-
     @RequiresPermission(allOf = [Manifest.permission.INTERNET, Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.WAKE_LOCK])
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        FirebaseAnalytics.getInstance(this.applicationContext).setCurrentScreen(this@MainActivity, "MainActivity", MainActivity::class.java.simpleName)
+        FirebaseAnalytics.getInstance(
+            this.applicationContext,
+        ).setCurrentScreen(this@MainActivity, "MainActivity", MainActivity::class.java.simpleName)
 
         val alarmHelper = AlarmHelper(applicationContext)
         alarmHelper.setAlarms()
 
         val navRoute = intent?.getStringExtra(Constants.EXTRA_NAVIGATION_ROUTE)
-        val startDestination = if (navRoute == Screen.NOTIFICATION.route) {
-            Screen.NOTIFICATION.route
-        } else {
-            Screen.MAIN.route
-        }
+        val startDestination =
+            if (navRoute == Screen.NOTIFICATION.route) {
+                Screen.NOTIFICATION.route
+            } else {
+                Screen.MAIN.route
+            }
 
         setContent {
             MakeAWishTheme {
@@ -80,7 +82,7 @@ fun MakeAWishApp(startDestination: String) {
                             Icon(Icons.Filled.Settings, contentDescription = "Settings")
                         }
                     },
-                    colors = TopAppBarDefaults.topAppBarColors()
+                    colors = TopAppBarDefaults.topAppBarColors(),
                 )
             } else {
                 TopAppBar(
@@ -90,7 +92,7 @@ fun MakeAWishApp(startDestination: String) {
                                 Screen.SETTINGS.route -> stringResource(R.string.settings)
                                 Screen.NOTIFICATION.route -> "Notification" // TODO resource
                                 else -> ""
-                            }
+                            },
                         )
                     },
                     navigationIcon = {
@@ -98,15 +100,15 @@ fun MakeAWishApp(startDestination: String) {
                             Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
                         }
                     },
-                    colors = TopAppBarDefaults.topAppBarColors()
+                    colors = TopAppBarDefaults.topAppBarColors(),
                 )
             }
-        }
+        },
     ) { innerPadding ->
         NavHost(
             navController = navController,
             startDestination = startDestination,
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         ) {
             composable(Screen.MAIN.route) {
                 MainScreen(onSettingsClick = { navController.navigate(Screen.SETTINGS.route) })

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/data/WishSource.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/data/WishSource.kt
@@ -1,5 +1,5 @@
 package tt.co.jesses.makeawish.data
 
 enum class WishSource {
-    FAB
+    FAB,
 }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/data/local/AppDatabase.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/data/local/AppDatabase.kt
@@ -15,11 +15,12 @@ abstract class AppDatabase : RoomDatabase() {
 
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
-                val instance = Room.databaseBuilder(
-                    context.applicationContext,
-                    AppDatabase::class.java,
-                    "app_database"
-                ).build()
+                val instance =
+                    Room.databaseBuilder(
+                        context.applicationContext,
+                        AppDatabase::class.java,
+                        "app_database",
+                    ).build()
                 INSTANCE = instance
                 instance
             }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/data/local/Wish.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/data/local/Wish.kt
@@ -9,5 +9,5 @@ data class Wish(
     val id: Int = 0,
     val timestamp: String,
     val source: String,
-    val wish: String
+    val wish: String,
 )

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/helpers/AlarmHelper.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/helpers/AlarmHelper.kt
@@ -19,7 +19,6 @@ class AlarmHelper(private val mContext: Context) {
     private val mAlarmIntent: PendingIntent
     private val mAlarmManager: AlarmManager
 
-
     init {
         val intent = Intent(mContext, AlarmReceiver::class.java)
         mAlarmIntent = PendingIntent.getBroadcast(mContext, 0, intent, PendingIntent.FLAG_IMMUTABLE)
@@ -60,6 +59,5 @@ class AlarmHelper(private val mContext: Context) {
         bundle.putBoolean(mContext.getString(R.string.prefs_enable_nighttime_alarms), nighttimeEnabled)
         bundle.putBoolean(mContext.getString(R.string.prefs_nighttime_set), nighttimeSet)
         FirebaseAnalytics.getInstance(mContext).logEvent(mContext.getString(R.string.prefs_log_event), bundle)
-
     }
 }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/helpers/CalendarHelper.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/helpers/CalendarHelper.kt
@@ -1,14 +1,12 @@
 package tt.co.jesses.makeawish.helpers
 
-import java.util.*
+import java.util.Calendar
 
 /**
  * Created by jessescott on 2017-02-27.
  */
 
 class CalendarHelper {
-
-
     val calendarsNighttime = arrayOfNulls<Calendar>(8)
     // AM - 10:10, 11:11, 12:12, 1:11, 2:22, 3:33, 4:44, 5:55
     // Getters
@@ -21,11 +19,9 @@ class CalendarHelper {
         setCalendarsNighttime()
     }
 
-
     // Setters
 
     private fun setCalendarsNighttime() {
-
         val calendar = Calendar.getInstance()
         calendar.timeInMillis = System.currentTimeMillis()
 
@@ -76,11 +72,9 @@ class CalendarHelper {
         calendar.set(Calendar.MINUTE, 55)
         calendarsNighttime[7] = calendar
         calendar.clear()
-
     }
 
     private fun setCalendarsDaytime() {
-
         val calendar = Calendar.getInstance()
         calendar.timeInMillis = System.currentTimeMillis()
 
@@ -131,6 +125,5 @@ class CalendarHelper {
         calendar.set(Calendar.MINUTE, 55)
         calendarsDaytime[7] = calendar
         calendar.clear()
-
     }
 }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/helpers/PreferenceHelper.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/helpers/PreferenceHelper.kt
@@ -1,6 +1,5 @@
 package tt.co.jesses.makeawish.helpers
 
-
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
@@ -13,7 +12,6 @@ import tt.co.jesses.makeawish.R
  */
 
 class PreferenceHelper(private val mContext: Context) {
-
     companion object {
         @Volatile
         private var encryptedPrefs: SharedPreferences? = null
@@ -32,20 +30,24 @@ class PreferenceHelper(private val mContext: Context) {
         }
 
         private fun createEncryptedSharedPreferences(context: Context): SharedPreferences {
-            val masterKey = MasterKey.Builder(context)
-                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                .build()
+            val masterKey =
+                MasterKey.Builder(context)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build()
 
             return EncryptedSharedPreferences.create(
                 context,
                 "secret_shared_prefs",
                 masterKey,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
             )
         }
 
-        private fun migrateToEncrypted(context: Context, encryptedPrefs: SharedPreferences) {
+        private fun migrateToEncrypted(
+            context: Context,
+            encryptedPrefs: SharedPreferences,
+        ) {
             val defaultPrefs = PreferenceManager.getDefaultSharedPreferences(context)
             // Check if we need to migrate: Default prefs has content, Encrypted is empty
             if (defaultPrefs.all.isNotEmpty() && encryptedPrefs.all.isEmpty()) {
@@ -58,8 +60,8 @@ class PreferenceHelper(private val mContext: Context) {
                         is Float -> editor.putFloat(key, value)
                         is Long -> editor.putLong(key, value)
                         is Set<*> -> {
-                             @Suppress("UNCHECKED_CAST")
-                             editor.putStringSet(key, value as Set<String>)
+                            @Suppress("UNCHECKED_CAST")
+                            editor.putStringSet(key, value as Set<String>)
                         }
                     }
                 }
@@ -69,13 +71,18 @@ class PreferenceHelper(private val mContext: Context) {
         }
     }
 
-    fun setPrefValueByKey(key: String, value: Boolean) {
+    fun setPrefValueByKey(
+        key: String,
+        value: Boolean,
+    ) {
         val preferences = getEncryptedSharedPreferences(mContext)
         val editor = preferences.edit()
         editor.putBoolean(key, value)
         editor.apply()
 
-        if (key == mContext.getString(R.string.prefs_enable_daytime_alarms) || key == mContext.getString(R.string.prefs_enable_nighttime_alarms)) {
+        if (key == mContext.getString(R.string.prefs_enable_daytime_alarms) ||
+            key == mContext.getString(R.string.prefs_enable_nighttime_alarms)
+        ) {
             triggerAlarmRegeneration()
         }
     }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/receivers/AlarmReceiver.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/receivers/AlarmReceiver.kt
@@ -19,35 +19,39 @@ import tt.co.jesses.makeawish.utils.Constants
  */
 
 class AlarmReceiver : BroadcastReceiver() {
-
-    override fun onReceive(context: Context, intent: Intent) {
-
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
         Log.d(TAG, "Received Intent: " + intent.dataString)
 
-        val notificationIntent = Intent(context, MainActivity::class.java).apply {
-            putExtra(Constants.EXTRA_NAVIGATION_ROUTE, Screen.NOTIFICATION.route)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
+        val notificationIntent =
+            Intent(context, MainActivity::class.java).apply {
+                putExtra(Constants.EXTRA_NAVIGATION_ROUTE, Screen.NOTIFICATION.route)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
 
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            0,
-            notificationIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
+        val pendingIntent =
+            PendingIntent.getActivity(
+                context,
+                0,
+                notificationIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
 
         val builder = NotificationCompat.Builder(context, "default")
 
         // TODO explore styles
-        //val inboxStyle = NotificationCompat.InboxStyle
-        //inboxStyle.setBigContentTitle("Event tracker details:")
-        //inboxStyle.addLine("foooo")
+        // val inboxStyle = NotificationCompat.InboxStyle
+        // inboxStyle.setBigContentTitle("Event tracker details:")
+        // inboxStyle.addLine("foooo")
 
         // TODO add RemoteInput to allow for inline wishing
 
         // TODO sound
 
-        val notification = builder
+        val notification =
+            builder
                 .setContentTitle(context.getString(R.string.receiver_title))
                 .setContentText(context.getString(R.string.receiver_text))
                 .setTicker(context.getString(R.string.receiver_ticker))
@@ -55,12 +59,11 @@ class AlarmReceiver : BroadcastReceiver() {
                 .setContentIntent(pendingIntent)
                 .setCategory(CATEGORY_ALARM)
                 .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
-                //.setStyle(inboxStyle)
+                // .setStyle(inboxStyle)
                 .build()
 
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.notify(0, notification)
-
     }
 
     companion object {

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/navigation/Screen.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/navigation/Screen.kt
@@ -5,7 +5,8 @@ import java.io.Serializable
 enum class Screen(val route: String) : Serializable {
     MAIN("main"),
     SETTINGS("settings"),
-    NOTIFICATION("notification");
+    NOTIFICATION("notification"),
+    ;
 
     companion object {
         fun fromRoute(route: String?): Screen? {

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/screens/MainScreen.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/screens/MainScreen.kt
@@ -49,25 +49,26 @@ fun MainScreen(onSettingsClick: () -> Unit) {
                 TextField(
                     value = wishText,
                     onValueChange = { wishText = it },
-                    label = { Text(stringResource(R.string.dialog_label_enter_wish)) }
+                    label = { Text(stringResource(R.string.dialog_label_enter_wish)) },
                 )
             },
             confirmButton = {
                 Button(
                     onClick = {
                         coroutineScope.launch {
-                            val wish = Wish(
-                                timestamp = System.currentTimeMillis().toString(),
-                                source = WishSource.FAB.name,
-                                wish = wishText
-                            )
+                            val wish =
+                                Wish(
+                                    timestamp = System.currentTimeMillis().toString(),
+                                    source = WishSource.FAB.name,
+                                    wish = wishText,
+                                )
                             withContext(Dispatchers.IO) {
                                 App.database.wishDao().insert(wish)
                             }
                             showDialog = false
                             wishText = "" // Reset text
                         }
-                    }
+                    },
                 ) {
                     Text(stringResource(R.string.dialog_btn_save))
                 }
@@ -76,7 +77,7 @@ fun MainScreen(onSettingsClick: () -> Unit) {
                 Button(onClick = { showDialog = false }) {
                     Text(stringResource(R.string.dialog_btn_cancel))
                 }
-            }
+            },
         )
     }
 
@@ -84,11 +85,11 @@ fun MainScreen(onSettingsClick: () -> Unit) {
         floatingActionButton = {
             FloatingActionButton(
                 onClick = { showDialog = true },
-                containerColor = MaterialTheme.colorScheme.secondary
+                containerColor = MaterialTheme.colorScheme.secondary,
             ) {
                 Icon(Icons.Filled.Add, contentDescription = "Add")
             }
-        }
+        },
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding).fillMaxSize()) {
             Text(
@@ -96,10 +97,11 @@ fun MainScreen(onSettingsClick: () -> Unit) {
                 style = MaterialTheme.typography.displayMedium,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp)
-                    .align(Alignment.TopCenter)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                        .align(Alignment.TopCenter),
             )
 
             // Placeholder for RecyclerView

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/screens/NotificationScreen.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/screens/NotificationScreen.kt
@@ -15,7 +15,7 @@ import tt.co.jesses.makeawish.R
 fun NotificationScreen() {
     Box(
         modifier = Modifier.fillMaxSize().padding(16.dp),
-        contentAlignment = Alignment.TopStart
+        contentAlignment = Alignment.TopStart,
     ) {
         Text(text = stringResource(R.string.notification_placeholder))
     }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/screens/SettingsScreen.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/screens/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package tt.co.jesses.makeawish.ui.screens
 
-import android.content.Context
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -34,25 +33,25 @@ fun SettingsScreen() {
             title = stringResource(R.string.settings_enable_notifications),
             key = stringResource(R.string.prefs_enable_notifications),
             defaultValue = true,
-            preferenceHelper = preferenceHelper
+            preferenceHelper = preferenceHelper,
         )
         SettingsCheckbox(
             title = stringResource(R.string.settings_enable_daytime_alarms),
             key = stringResource(R.string.prefs_enable_daytime_alarms),
             defaultValue = true,
-            preferenceHelper = preferenceHelper
+            preferenceHelper = preferenceHelper,
         )
         SettingsCheckbox(
             title = stringResource(R.string.settings_enable_nighttime_alarms),
             key = stringResource(R.string.prefs_enable_nighttime_alarms),
             defaultValue = false,
-            preferenceHelper = preferenceHelper
+            preferenceHelper = preferenceHelper,
         )
         SettingsCheckbox(
             title = stringResource(R.string.settings_enable_analytics),
             key = stringResource(R.string.prefs_enable_analytics),
             defaultValue = true,
-            preferenceHelper = preferenceHelper
+            preferenceHelper = preferenceHelper,
         )
     }
 }
@@ -62,7 +61,7 @@ fun SettingsCheckbox(
     title: String,
     key: String,
     defaultValue: Boolean,
-    preferenceHelper: PreferenceHelper
+    preferenceHelper: PreferenceHelper,
 ) {
     var checked by remember {
         mutableStateOf(
@@ -70,7 +69,7 @@ fun SettingsCheckbox(
                 preferenceHelper.getPrefValueByKey(key)
             } catch (e: Exception) {
                 defaultValue
-            }
+            },
         )
     }
 
@@ -89,19 +88,19 @@ fun SettingsCheckbox(
                     checked = it
                     preferenceHelper.setPrefValueByKey(key, it)
                 },
-                role = Role.Checkbox
+                role = Role.Checkbox,
             )
             .padding(vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Checkbox(
             checked = checked,
-            onCheckedChange = null // null recommended for accessibility with toggleable modifier
+            onCheckedChange = null,
         )
         Text(
             text = title,
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(start = 16.dp)
+            modifier = Modifier.padding(start = 16.dp),
         )
     }
 }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/theme/Theme.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/theme/Theme.kt
@@ -15,40 +15,43 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
-private val DarkColorScheme = darkColorScheme(
-    primary = BlueGrey500,
-    secondary = Amber500,
-    tertiary = BlueGrey700
-)
+private val DarkColorScheme =
+    darkColorScheme(
+        primary = BlueGrey500,
+        secondary = Amber500,
+        tertiary = BlueGrey700,
+    )
 
-private val LightColorScheme = lightColorScheme(
-    primary = BlueGrey500,
-    secondary = Amber500,
-    tertiary = BlueGrey700,
-    background = Icons,
-    surface = Icons,
-    onPrimary = Icons,
-    onSecondary = PrimaryText,
-    onTertiary = Icons,
-    onBackground = PrimaryText,
-    onSurface = PrimaryText,
-)
+private val LightColorScheme =
+    lightColorScheme(
+        primary = BlueGrey500,
+        secondary = Amber500,
+        tertiary = BlueGrey700,
+        background = Icons,
+        surface = Icons,
+        onPrimary = Icons,
+        onSecondary = PrimaryText,
+        onTertiary = Icons,
+        onBackground = PrimaryText,
+        onSurface = PrimaryText,
+    )
 
 @Composable
 fun MakeAWishTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+    val colorScheme =
+        when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
+            darkTheme -> DarkColorScheme
+            else -> LightColorScheme
         }
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
@@ -61,6 +64,6 @@ fun MakeAWishTheme(
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,
-        content = content
+        content = content,
     )
 }

--- a/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/theme/Type.kt
+++ b/MakeAWish/app/src/main/java/tt/co/jesses/makeawish/ui/theme/Type.kt
@@ -6,12 +6,14 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-val Typography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
+val Typography =
+    Typography(
+        bodyLarge =
+            TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                lineHeight = 24.sp,
+                letterSpacing = 0.5.sp,
+            ),
     )
-)

--- a/MakeAWish/build.gradle
+++ b/MakeAWish/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.1'
@@ -14,6 +15,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.4.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.9.22-1.0.18"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:12.1.0"
     }
 }
 


### PR DESCRIPTION
This change adds ktlint support to the project for consistent Kotlin code styling. It integrates the ktlint-gradle plugin and configures it via an .editorconfig file, specifically tailored for Android and Jetpack Compose. All existing Kotlin source files have been formatted to pass the initial lint check. Furthermore, the CI workflow has been updated to execute the lint check before any unit or UI tests, ensuring that only lint-free code is tested and merged.

Fixes #32

---
*PR created automatically by Jules for task [14288587492922983690](https://jules.google.com/task/14288587492922983690) started by @JesseScott*